### PR TITLE
build(deps): bump Rails to 7

### DIFF
--- a/form_verification.gemspec
+++ b/form_verification.gemspec
@@ -1,4 +1,4 @@
-$:.push File.expand_path('../lib', __FILE__)
+$:.push File.expand_path('lib', __dir__)
 
 # Maintain your gem's version:
 require 'form_verification/version'
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib,vendor}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'rails', '>= 4.0.0', '<= 6.1'
+  s.add_dependency 'rails', '>= 4.0.0', '< 7.1'
 
   s.add_development_dependency 'sqlite3'
 end

--- a/lib/form_verification/version.rb
+++ b/lib/form_verification/version.rb
@@ -1,3 +1,3 @@
 module FormVerification
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
# build(deps): bump Rails to 7

![ruby logo](https://img.shields.io/badge/Ruby-informational?style=flat&logo=ruby&logoColor=white&color=CC0000)

## 🗃 Carte(s) Trello

- [Rails 6.1 ➡️ 7.0](https://trello.com/c/fkuOrI39)

## ⚙️ Back

- Bump gemspec dependency to Rails 7

## 📺 Comment tester

- In your main project Gemfile, use:

```
gem 'form_verification', '1.2.0', git: 'https://github.com/Kinoba/form_verification.git', branch: 'build/bump-rails-dependency-to-7'
```
